### PR TITLE
FIX: fields for Before and After filters

### DIFF
--- a/src/app/domain/accounts/models.py
+++ b/src/app/domain/accounts/models.py
@@ -26,8 +26,6 @@ class User(orm.DatabaseModel, orm.AuditColumns):
     is_superuser: Mapped[bool] = mapped_column(default=False)
     is_verified: Mapped[bool] = mapped_column(default=False)
     verified_at: Mapped[datetime | None]
-    created: Mapped[datetime] = mapped_column(server_default=func.now())
-    updated: Mapped[datetime] = mapped_column(server_default=func.now(), server_onupdate=func.now())
     # -----------
     # ORM Relationships
     # ------------

--- a/src/app/domain/accounts/models.py
+++ b/src/app/domain/accounts/models.py
@@ -26,7 +26,8 @@ class User(orm.DatabaseModel, orm.AuditColumns):
     is_superuser: Mapped[bool] = mapped_column(default=False)
     is_verified: Mapped[bool] = mapped_column(default=False)
     verified_at: Mapped[datetime | None]
-    joined_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    created: Mapped[datetime] = mapped_column(server_default=func.now())
+    updated: Mapped[datetime] = mapped_column(server_default=func.now(), server_onupdate=func.now())
     # -----------
     # ORM Relationships
     # ------------

--- a/src/app/domain/accounts/schemas.py
+++ b/src/app/domain/accounts/schemas.py
@@ -30,7 +30,8 @@ class User(CamelizedBaseModel):
     is_superuser: bool
     is_active: bool
     is_verified: bool
-    joined_at: datetime
+    created: datetime
+    updated: datetime
     teams: list[UserTeam] | None = []
 
 


### PR DESCRIPTION
https://github.com/cofin/starlite-full-stack-example/blob/master/src/app/lib/dependencies.py#L71

Before and After filters needing a model field `created` and `updated` - if not present, an `/api/users` call gives an error for field not found when filtering.